### PR TITLE
fix: Ensure the directory exists before write it

### DIFF
--- a/internal/modules/order-summary/module.go
+++ b/internal/modules/order-summary/module.go
@@ -87,6 +87,11 @@ func writeToFile(tokenSymbol string, rateToFiatAmount map[float64]float64, rateT
 		fileContent += fmt.Sprintf("%f,%f,%f\n", key, rateToFiatAmount[key], rateToTokenAmount[key])
 	}
 
+	// Ensure the directory exists
+	if err := os.MkdirAll("./reports", os.ModePerm); err != nil {
+		return err
+	}
+
 	// write to file
 	file, err := os.Create(fmt.Sprintf("./reports/%s_order_summary.csv", tokenSymbol))
 	if err != nil {


### PR DESCRIPTION
need to check the directory exists
![b51c93b3-6daa-4a11-9afb-1bd995cc0eb8](https://github.com/user-attachments/assets/e467e7e0-43ce-4b85-a0db-305e7d2df6e8)
